### PR TITLE
Add Slack support link and FAQ page to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ State-based hierarchical MoSeq (shMoSeq) is a method for discovering high-level 
 
 - [Tutorial](https://state-moseq.readthedocs.io/en/latest/example_data_tutorial.html)
 
+## Support
+For questions and discussion, join the [MoSeq Slack workspace](https://join.slack.com/t/moseqworkspace/shared_invite/zt-151x0shoi-z4J0_g_5rwJDlO1IfCU34A).
 
 # License
 shMoSeq is freely available for academic use under a license provided by Harvard University. Please refer to the license file for details. If you are interested in using shMoSeq for commercial purposes please contact Bob Datta directly at srdatta@hms.harvard.edu, who will put you in touch with the appropriate people in the Harvard Technology Transfer office.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,9 @@
+FAQ
+===
+
+The lagged mutual information plot shows an upward trend at large lags. Is this a problem?
+-------------------------------------------------------------------------------------------
+
+This typically happens when the lag approaches the length of the recordings. Mutual information is sensitive to the number of independent data points available, and at large lags there are fewer timepoint-pairs that are far enough apart, which inflates the MI estimate. This effect is more pronounced with shorter recordings (e.g. ~10 minutes).
+
+This is not a cause for concern. The purpose of the plot is to confirm that the data has temporal structure at longer timescales than a Markov model would predict. The gap between the real and Markov MI curves at moderate lags (e.g. a few seconds up to 20-30s) indicates the range of state durations you should expect. If you want to include this plot in a paper, consider restricting the x-axis to lags where the estimates are stable (before they start rising).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,9 @@ shMoSeq
      - `License <https://github.com/dattalab/state-moseq/blob/main/LICENSE.md>`_
 
 
-State-based hierarchical MoSeq (shMoSeq) is a method for discovering high-level states in animal behavior. Given low-level behavior labels (e.g. MoSeq syllables), shMoSeq fits a hierarchical hidden Markov model to identify how behaviors are clustered over time. 
+State-based hierarchical MoSeq (shMoSeq) is a method for discovering high-level states in animal behavior. Given low-level behavior labels (e.g. MoSeq syllables), shMoSeq fits a hierarchical hidden Markov model to identify how behaviors are clustered over time.
+
+For questions and discussion, join the `MoSeq Slack workspace <https://join.slack.com/t/moseqworkspace/shared_invite/zt-151x0shoi-z4J0_g_5rwJDlO1IfCU34A>`_.
 
 
 Installation
@@ -62,3 +64,8 @@ To run state-moseq in jupyter, either launch jupyterlab directly from the ``shmo
    hhmm_standard
    utils
    viz
+
+.. toctree::
+   :maxdepth: 1
+
+   faq


### PR DESCRIPTION
- Add a link to the MoSeq Slack workspace in the README and docs landing page for user support
- Add a new FAQ page with guidance on interpreting the lagged mutual information plot
- Wire the FAQ into the docs table of contents