### PR TITLE
Add centroid validation to generate_grid_movies and FAQ entry

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -7,3 +7,32 @@ The lagged mutual information plot shows an upward trend at large lags. Is this 
 This typically happens when the lag approaches the length of the recordings. Mutual information is sensitive to the number of independent data points available, and at large lags there are fewer timepoint-pairs that are far enough apart, which inflates the MI estimate. This effect is more pronounced with shorter recordings (e.g. ~10 minutes).
 
 This is not a cause for concern. The purpose of the plot is to confirm that the data has temporal structure at longer timescales than a Markov model would predict. The gap between the real and Markov MI curves at moderate lags (e.g. a few seconds up to 20-30s) indicates the range of state durations you should expect. If you want to include this plot in a paper, consider restricting the x-axis to lags where the estimates are stable (before they start rising).
+
+``generate_grid_movies`` threw an error about NaNs or negatives in my centroids — what's going on?
+----------------------------------------------------------------------------------------------------
+
+**Negative values in centroids**
+
+``generate_grid_movies`` expects centroids with a **corner-of-frame origin**, where (0, 0) is a corner of the image. If you are using depth-MoSeq data, the most likely cause of negative centroids is that you are passing centroids with a **center-of-frame origin**, where (0, 0) is the center of the image. Depth-MoSeq extracts both — make sure you are using the corner-origin (px) centroids rather than the center-origin (mm) centroids.
+
+If you are *not* using depth-MoSeq data (or you are already using the px centroids), you likely have an upstream issue. Inspect your centroids to understand where the negative values are coming from — for example, plot them over time and look for outliers or systematic offsets.
+
+**NaN values in centroids**
+
+NaN values typically arise from:
+
+- **Dropped frames** during depth video collection, or
+- **Frames with no detected keypoints** (if using keypoint-MoSeq).
+
+Before calling ``generate_grid_movies``, make sure that NaNs are few and far between and don't occur in long contiguous runs (which would indicate a more serious data-quality issue). Then interpolate the NaNs using your method of choice. A simple linear interpolation with pandas works well:
+
+.. code-block:: python
+
+   import pandas as pd
+   import numpy as np
+
+   # centroids[key] has shape (n_timesteps, 2)
+   for key in centroids:
+       df = pd.DataFrame(centroids[key], columns=["x", "y"])
+       df = df.interpolate(method="linear", limit_direction="both")
+       centroids[key] = df.values

--- a/state_moseq/viz.py
+++ b/state_moseq/viz.py
@@ -146,6 +146,25 @@ def generate_grid_movies(
     Returns:
         instances: Sampled instances used for grid movies.
     """
+    # Check centroids for negative values and NaNs
+    faq_url = "https://state-moseq.readthedocs.io/en/latest/faq.html#generate-grid-movies-threw-an-error-about-nans-or-negatives-in-my-centroids-what-s-going-on"
+    has_negative = any(np.any(np.asarray(c) < 0) for c in centroids.values())
+    has_nan = any(np.any(np.isnan(np.asarray(c))) for c in centroids.values())
+    if has_negative:
+        raise ValueError(
+            "Negative values found in centroids dict. "
+            "The most common cause of this is using the mm centroid measurement "
+            "from depth MoSeq instead of the px centroid measurement. "
+            f"See the FAQ for details: {faq_url}"
+        )
+    if has_nan:
+        raise ValueError(
+            "NaN values found in centroids dict. "
+            "This is likely due to dropped frames or frames with no detected keypoints. "
+            "Interpolate NaNs before calling this function. "
+            f"See the FAQ for details: {faq_url}"
+        )
+
     os.makedirs(output_dir, exist_ok=True)
     videos = {k: OpenCVReader(path) for k, path in video_paths.items()}
     fps = videos[list(video_paths.keys())[0]].fps


### PR DESCRIPTION
## Summary
- Adds guard clauses to `generate_grid_movies` that check for negative values and NaNs in the centroids dict before processing, with clear error messages pointing users to the FAQ
- Adds a new FAQ entry explaining the most common causes (center-of-frame vs corner-of-frame origin for negatives; dropped frames / missing keypoints for NaNs) and how to fix them, including a pandas linear interpolation example

## Context
A user ran into a confusing error from `generate_grid_movies` caused by passing center-origin (mm) centroids from depth MoSeq instead of corner-origin (px) centroids. The raw error was hard to diagnose, so this adds early validation with actionable guidance.